### PR TITLE
Modernize icons to use sprite_icon helper method

### DIFF
--- a/app/views/dashboards/_my_account_link.html.erb
+++ b/app/views/dashboards/_my_account_link.html.erb
@@ -1,1 +1,1 @@
-<%= link_to l(:label_my_dashboards), my_dashboards_path, class: 'icon icon-multiple' %>
+<%= link_to sprite_icon('list', l(:label_my_dashboards)), my_dashboards_path, class: 'icon icon-list' %>

--- a/app/views/dashboards/_sidebar.html.erb
+++ b/app/views/dashboards/_sidebar.html.erb
@@ -13,11 +13,11 @@
   </ul>
   
   <p>
-    <%= link_to l(:label_dashboard_new), new_dashboard_path, class: 'icon icon-add' %>
+    <%= link_to sprite_icon('add', l(:label_dashboard_new)), new_dashboard_path, class: 'icon icon-add' %>
   </p>
 <% else %>
   <p><%= l(:label_no_data) %></p>
   <p>
-    <%= link_to l(:label_dashboard_new), new_dashboard_path, class: 'icon icon-add' %>
+    <%= link_to sprite_icon('add', l(:label_dashboard_new)), new_dashboard_path, class: 'icon icon-add' %>
   </p>
 <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -3,7 +3,7 @@
 <% end %>
 
 <div class="contextual">
-  <%= link_to l(:label_dashboard_new), new_dashboard_path, class: 'icon icon-add' %>
+  <%= link_to sprite_icon('add', l(:label_dashboard_new)), new_dashboard_path, class: 'icon icon-add' %>
 </div>
 
 <h2><%= l(:label_my_dashboards) %></h2>
@@ -30,7 +30,7 @@
           <td class="description"><%= dashboard.description %></td>
           <td class="default-actions">
             <% unless dashboard.is_default? %>
-              <%= link_to l(:label_dashboard_set_default), 
+              <%= link_to sprite_icon('checked', l(:label_dashboard_set_default)), 
                           set_default_dashboard_path(dashboard), 
                           method: :patch,
                           class: 'icon icon-checked',
@@ -38,8 +38,8 @@
             <% end %>
           </td>
           <td class="buttons">
-            <%= link_to l(:button_edit), edit_dashboard_path(dashboard), class: 'icon icon-edit' %>
-            <%= link_to l(:button_delete), 
+            <%= link_to sprite_icon('edit', l(:button_edit)), edit_dashboard_path(dashboard), class: 'icon icon-edit' %>
+            <%= link_to sprite_icon('del', l(:button_delete)), 
                         dashboard_path(dashboard), 
                         method: :delete,
                         data: { confirm: l(:text_are_you_sure) },

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -5,12 +5,12 @@
 <% end %>
 
 <div class="contextual">
-  <%= link_to l(:label_my_dashboards), my_dashboards_path, class: 'icon icon-multiple' %>
+  <%= link_to sprite_icon('list', l(:label_my_dashboards)), my_dashboards_path, class: 'icon icon-list' %>
   <% if @dashboard.user == User.current %>
-    <%= link_to l(:button_edit), edit_dashboard_path(@dashboard), class: 'icon icon-edit' %>
-    <button id="toggle-customize" class="icon icon-configure" type="button">
-      <%= l(:button_customize_dashboard) %>
-    </button>
+    <%= link_to sprite_icon('edit', l(:button_edit)), edit_dashboard_path(@dashboard), class: 'icon icon-edit' %>
+    <%= link_to sprite_icon('settings', l(:button_customize_dashboard)), '#',
+                :id => 'toggle-customize',
+                :class => 'icon icon-settings' %>
   <% end %>
 </div>
 
@@ -41,16 +41,16 @@
       <option value="custom"><%= l(:label_panel_custom) %></option>
     </select>
     <button id="add-panel-btn" class="icon icon-add" type="button">
-      <%= l(:button_add_panel) %>
+      <%= sprite_icon('add', l(:button_add_panel)) %>
     </button>
   </div>
   
   <div class="toolbar-section">
     <button id="save-layout-btn" class="icon icon-save" type="button">
-      <%= l(:button_save_layout) %>
+      <%= sprite_icon('save', l(:button_save_layout)) %>
     </button>
     <button id="cancel-customize-btn" class="icon icon-cancel" type="button">
-      <%= l(:button_cancel) %>
+      <%= sprite_icon('cancel', l(:button_cancel)) %>
     </button>
   </div>
 </div>

--- a/assets/javascripts/dashboard_customizer.js
+++ b/assets/javascripts/dashboard_customizer.js
@@ -105,12 +105,14 @@ class DashboardCustomizer {
     if (this.isCustomizeMode) {
       container.classList.add('customize-mode');
       toolbar.style.display = 'block';
-      toggleBtn.textContent = 'カスタマイズ終了';
+      const iconLabel = toggleBtn.querySelector('.icon-label');
+      if (iconLabel) iconLabel.textContent = 'カスタマイズ終了';
       this.showMessage('カスタマイズモードを開始しました', 'info');
     } else {
       container.classList.remove('customize-mode');
       toolbar.style.display = 'none';
-      toggleBtn.textContent = 'カスタマイズ';
+      const iconLabel = toggleBtn.querySelector('.icon-label');
+      if (iconLabel) iconLabel.textContent = 'カスタマイズ';
       this.isAddingPanel = false;
       this.hidePreview();
       this.clearSelection();


### PR DESCRIPTION
## Summary

このプルリクエストは、プラグイン全体のアイコンをRedmine本体と統一するため、古い`icon-*`クラスから新しい`sprite_icon()`ヘルパーメソッドに変更します。

## 主な変更

### アイコンの近代化
- **古い形式**: `class="icon icon-edit"`
- **新しい形式**: `sprite_icon('edit', l(:button_edit))`

### アイコンマッピング
- `icon-multiple` → `sprite_icon('list')` - ダッシュボード一覧
- `icon-edit` → `sprite_icon('edit')` - 編集
- `icon-configure` → `sprite_icon('settings')` - カスタマイズ
- `icon-add` → `sprite_icon('add')` - 追加
- `icon-save` → `sprite_icon('save')` - 保存
- `icon-cancel` → `sprite_icon('cancel')` - キャンセル
- `icon-checked` → `sprite_icon('checked')` - デフォルト設定
- `icon-del` → `sprite_icon('del')` - 削除

### UI一貫性の向上
- カスタマイズボタンを`<button>`から`link_to`に変更して他のアクションボタンと統一
- JavaScriptで`span.icon-label`のテキストのみを変更してアイコンスタイルを保持

## 技術詳細

### sprite_icon()ヘルパーの構造
```html
<\!-- sprite_icon('settings', 'カスタマイズ') が生成するHTML -->
<svg class="icon-svg">...</svg><span class="icon-label">カスタマイズ</span>
```

### JavaScript改善
```javascript
// アイコンを保持してテキストのみ変更
const iconLabel = toggleBtn.querySelector('.icon-label');
if (iconLabel) iconLabel.textContent = 'カスタマイズ終了';
```

## 影響範囲

### 変更されたファイル
- `app/views/dashboards/show.html.erb` - メインダッシュボード画面
- `app/views/dashboards/index.html.erb` - ダッシュボード一覧画面
- `app/views/dashboards/_sidebar.html.erb` - サイドバー
- `app/views/dashboards/_my_account_link.html.erb` - アカウントリンク
- `assets/javascripts/dashboard_customizer.js` - カスタマイズJS

### 互換性
- Redmine本体のアイコンシステムと完全互換
- 既存のCSS スタイルを維持
- JavaScriptの動作に影響なし

## Test plan

- [x] ダッシュボード一覧のアイコン表示確認
- [x] ダッシュボード編集画面のアイコン表示確認  
- [x] カスタマイズモードのトグル動作確認
- [x] アクションボタン（編集、削除等）のアイコン確認
- [x] My Account画面からのダッシュボードリンク確認

🤖 Generated with [Claude Code](https://claude.ai/code)