### PR TITLE
Fix dashboard navigation by adding links to dashboard names

### DIFF
--- a/app/views/dashboards/_sidebar.html.erb
+++ b/app/views/dashboards/_sidebar.html.erb
@@ -4,7 +4,7 @@
   <ul>
     <% dashboards.each do |dashboard| %>
       <li>
-        <%= dashboard.name %>
+        <%= link_to dashboard.name, dashboard_path(dashboard) %>
         <% if dashboard.is_default? %>
           <span class="default-indicator">*</span>
         <% end %>

--- a/app/views/dashboards/index.html.erb
+++ b/app/views/dashboards/index.html.erb
@@ -22,7 +22,7 @@
       <% @dashboards.each do |dashboard| %>
         <tr class="<%= cycle('odd', 'even') %> <%= 'default-dashboard' if dashboard.is_default? %>">
           <td class="name">
-            <%= dashboard.name %>
+            <%= link_to dashboard.name, dashboard_path(dashboard) %>
             <% if dashboard.is_default? %>
               <span class="default-indicator">(<%= l(:label_dashboard_default) %>)</span>
             <% end %>


### PR DESCRIPTION
## Summary

このプルリクエストは、ダッシュボード一覧からダッシュボード表示画面への移動ができない問題を修正します。ダッシュボード名をクリック可能なリンクに変更して、直感的なナビゲーションを実現します。

## 問題

現在、以下の画面でダッシュボード名が単純なテキストとして表示されており、クリックしてもダッシュボード表示画面に移動できません：

1. **ユーザーダッシュボード一覧画面** (`/dashboards`)
2. **サイドバーのダッシュボード一覧** (アカウントページ等)

## 解決策

ダッシュボード名を`dashboard_path(dashboard)`へのリンクに変更：

### Before
```erb
<%= dashboard.name %>
```

### After  
```erb
<%= link_to dashboard.name, dashboard_path(dashboard) %>
```

## 変更内容

### ユーザーダッシュボード一覧画面
- **ファイル**: `app/views/dashboards/index.html.erb`
- **変更**: テーブル内のダッシュボード名をクリック可能なリンクに変更
- **動作**: ダッシュボード名をクリックすると、そのダッシュボードの表示画面（カスタマイズ可能な画面）に移動

### サイドバーのダッシュボード一覧  
- **ファイル**: `app/views/dashboards/_sidebar.html.erb`
- **変更**: リスト内のダッシュボード名をクリック可能なリンクに変更
- **動作**: サイドバーからもダッシュボード表示画面に直接アクセス可能

## ユーザビリティ向上

- **直感的操作**: ダッシュボード名をクリックすれば表示画面に移動する自然な動作
- **アクセス性向上**: 複数の導線からダッシュボードにアクセス可能
- **一貫性**: 他のRedmine機能と同様のナビゲーション体験

## 影響範囲

- **変更ファイル**: 2ファイル（ビューのみ）
- **後方互換性**: 完全に維持（既存機能に影響なし）
- **パフォーマンス**: 影響なし（単純なリンク追加）

## Test plan

- [x] ダッシュボード一覧画面でダッシュボード名のリンク動作確認
- [x] サイドバーでダッシュボード名のリンク動作確認
- [x] リンク先がダッシュボード表示画面（カスタマイズ機能付き）であることを確認
- [x] 既存のテストが通ることを確認

🤖 Generated with [Claude Code](https://claude.ai/code)