### PR TITLE
Fix panel delete icon consistency with Redmine core

### DIFF
--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -117,7 +117,8 @@ document.addEventListener('DOMContentLoaded', function() {
       panelTypeCustom: '<%= l(:label_panel_custom) %>',
       panelTypeFallback: '<%= l(:label_panel_type) %>',
       panelContentPlaceholder: '<%= l(:text_panel_content_placeholder) %>',
-      panelConfigRequired: '<%= l(:text_panel_config_required) %>'
+      panelConfigRequired: '<%= l(:text_panel_config_required) %>',
+      deleteIconSvg: '<%= sprite_icon('close').html_safe %>'
     }
   });
 });

--- a/app/views/dashboards/show.html.erb
+++ b/app/views/dashboards/show.html.erb
@@ -65,8 +65,8 @@
         
         <div class="panel-header">
           <span class="panel-title"><%= h(panel.title) %></span>
-          <div class="panel-controls" style="display: none;">
-            <button class="panel-delete" data-panel-id="<%= panel.id %>" title="<%= l(:button_delete) %>">×</button>
+          <div class="panel-controls">
+            <a href="#" class="panel-delete" data-panel-id="<%= panel.id %>" title="<%= l(:button_delete) %>"><%= sprite_icon('close') %></a>
           </div>
         </div>
         
@@ -75,7 +75,7 @@
         </div>
         
         <!-- リサイズハンドル -->
-        <div class="resize-handle resize-se" style="display: none;"></div>
+        <div class="resize-handle resize-se"></div>
       </div>
     <% end %>
     

--- a/assets/javascripts/dashboard_customizer.js
+++ b/assets/javascripts/dashboard_customizer.js
@@ -100,12 +100,14 @@ class DashboardCustomizer {
     if (this.isCustomizeMode) {
       container.classList.add('customize-mode');
       toolbar.style.display = 'block';
+      this.disablePanelTooltips();
       const iconLabel = toggleBtn.querySelector('.icon-label');
       if (iconLabel) iconLabel.textContent = this.translations.customizeEnd || 'End Customize';
       this.showMessage(this.translations.customizeModeStarted || 'Customize mode started', 'info');
     } else {
       container.classList.remove('customize-mode');
       toolbar.style.display = 'none';
+      this.enablePanelTooltips();
       const iconLabel = toggleBtn.querySelector('.icon-label');
       if (iconLabel) iconLabel.textContent = this.translations.customize || 'Customize';
       this.isAddingPanel = false;
@@ -475,6 +477,26 @@ class DashboardCustomizer {
       this.selectedPanel.classList.remove('selected');
       this.selectedPanel = null;
     }
+  }
+
+  disablePanelTooltips() {
+    const deleteButtons = document.querySelectorAll('.panel-delete');
+    deleteButtons.forEach(btn => {
+      if (btn.title) {
+        btn.dataset.originalTitle = btn.title;
+        btn.removeAttribute('title');
+      }
+    });
+  }
+
+  enablePanelTooltips() {
+    const deleteButtons = document.querySelectorAll('.panel-delete');
+    deleteButtons.forEach(btn => {
+      if (btn.dataset.originalTitle) {
+        btn.title = btn.dataset.originalTitle;
+        delete btn.dataset.originalTitle;
+      }
+    });
   }
 
 

--- a/assets/javascripts/dashboard_customizer.js
+++ b/assets/javascripts/dashboard_customizer.js
@@ -201,7 +201,7 @@ class DashboardCustomizer {
       <div class="panel-header">
         <span class="panel-title">${this.escapeHtml(panelData.title)}</span>
         <div class="panel-controls">
-          <a href="#" class="panel-delete" data-panel-id="${panelData.id}" title="${this.translations.deleteLabel || 'Delete'}"><span class="icon icon-close"></span></a>
+          <a href="#" class="panel-delete" data-panel-id="${panelData.id}" title="${this.translations.deleteLabel || 'Delete'}">${this.translations.deleteIconSvg || '<svg class="s18 icon-svg" aria-hidden="true"><use href="/assets/icons-1857f271.svg#icon--close"></use></svg>'}</a>
         </div>
       </div>
       <div class="panel-content">

--- a/assets/javascripts/dashboard_customizer.js
+++ b/assets/javascripts/dashboard_customizer.js
@@ -51,27 +51,32 @@ class DashboardCustomizer {
   bindPanelEvents() {
     const panels = document.querySelectorAll('.dashboard-panel');
     panels.forEach(panel => {
-      // ドラッグ開始
-      panel.addEventListener('mousedown', (e) => this.handlePanelMouseDown(e, panel));
-      
-      // パネル選択
-      panel.addEventListener('click', (e) => this.selectPanel(panel));
-
-      // 削除ボタン
-      const deleteBtn = panel.querySelector('.panel-delete');
-      if (deleteBtn) {
-        deleteBtn.addEventListener('click', (e) => {
-          e.stopPropagation();
-          this.deletePanel(panel);
-        });
-      }
-
-      // リサイズハンドル
-      const resizeHandle = panel.querySelector('.resize-handle');
-      if (resizeHandle) {
-        resizeHandle.addEventListener('mousedown', (e) => this.handleResizeMouseDown(e, panel));
-      }
+      this.bindSinglePanelEvents(panel);
     });
+  }
+
+  bindSinglePanelEvents(panel) {
+    // ドラッグ開始
+    panel.addEventListener('mousedown', (e) => this.handlePanelMouseDown(e, panel));
+    
+    // パネル選択
+    panel.addEventListener('click', (e) => this.selectPanel(panel));
+
+    // 削除ボタン
+    const deleteBtn = panel.querySelector('.panel-delete');
+    if (deleteBtn) {
+      deleteBtn.addEventListener('click', (e) => {
+        e.preventDefault();
+        e.stopPropagation();
+        this.deletePanel(panel);
+      });
+    }
+
+    // リサイズハンドル
+    const resizeHandle = panel.querySelector('.resize-handle');
+    if (resizeHandle) {
+      resizeHandle.addEventListener('mousedown', (e) => this.handleResizeMouseDown(e, panel));
+    }
   }
 
   setupGrid() {
@@ -195,8 +200,8 @@ class DashboardCustomizer {
     panel.innerHTML = `
       <div class="panel-header">
         <span class="panel-title">${this.escapeHtml(panelData.title)}</span>
-        <div class="panel-controls" style="display: none;">
-          <button class="panel-delete" data-panel-id="${panelData.id}" title="${this.translations.deleteLabel || 'Delete'}">×</button>
+        <div class="panel-controls">
+          <a href="#" class="panel-delete" data-panel-id="${panelData.id}" title="${this.translations.deleteLabel || 'Delete'}"><span class="icon icon-close"></span></a>
         </div>
       </div>
       <div class="panel-content">
@@ -210,11 +215,11 @@ class DashboardCustomizer {
           </div>
         </div>
       </div>
-      <div class="resize-handle resize-se" style="display: none;"></div>
+      <div class="resize-handle resize-se"></div>
     `;
 
     grid.appendChild(panel);
-    this.bindPanelEvents();
+    this.bindSinglePanelEvents(panel);
   }
 
   handlePanelMouseDown(e, panel) {
@@ -443,6 +448,10 @@ class DashboardCustomizer {
     this.apiCall('DELETE', this.urls.deletePanel, { panel_id: panelId })
       .then(response => {
         if (response.status === 'success') {
+          // 選択状態をクリア
+          if (this.selectedPanel === panel) {
+            this.clearSelection();
+          }
           panel.remove();
           this.showMessage(response.message, 'success');
         } else {
@@ -467,6 +476,7 @@ class DashboardCustomizer {
       this.selectedPanel = null;
     }
   }
+
 
   showPreview(gridX, gridY, gridWidth, gridHeight) {
     let preview = document.getElementById('panel-preview');

--- a/assets/stylesheets/dashboard_panels.css
+++ b/assets/stylesheets/dashboard_panels.css
@@ -119,10 +119,6 @@
   gap: 4px;
 }
 
-.customize-mode .panel-controls {
-  display: flex;
-}
-
 .panel-delete {
   text-decoration: none;
 }

--- a/assets/stylesheets/dashboard_panels.css
+++ b/assets/stylesheets/dashboard_panels.css
@@ -115,27 +115,16 @@
 }
 
 .panel-controls {
-  display: flex;
+  display: none;
   gap: 4px;
 }
 
-.panel-delete {
-  background: #d9534f;
-  color: white;
-  border: none;
-  border-radius: 2px;
-  width: 20px;
-  height: 20px;
-  cursor: pointer;
-  font-size: 12px;
-  line-height: 1;
+.customize-mode .panel-controls {
   display: flex;
-  align-items: center;
-  justify-content: center;
 }
 
-.panel-delete:hover {
-  background: #c9302c;
+.panel-delete {
+  text-decoration: none;
 }
 
 /* Panel Content */


### PR DESCRIPTION
## Summary
- Replace custom × character with Redmine's standard icon-close
- Fix newly added panels not showing delete icons in customize mode
- Resolve tooltip persistence issue after panel deletion

## Changes
- **Icon modernization**: Use `sprite_icon('close')` in HTML templates and equivalent SVG in JavaScript
- **Element consistency**: Change delete buttons from `button` to `a` elements for UI consistency
- **CSS optimization**: Remove duplicate panel control visibility rules and custom red styling
- **Maintainability**: Use server-side icon generation for dynamic panels via translations object
- **Tooltip management**: Disable tooltips during customize mode to prevent persistence issues

## Test plan
- [x] Verify delete icons appear consistently across static and dynamic panels
- [x] Confirm icons match Redmine core styling (icon-close)
- [x] Test tooltip behavior during panel deletion
- [x] Validate customize mode functionality

🤖 Generated with [Claude Code](https://claude.ai/code)